### PR TITLE
#005 Create the security config basic level

### DIFF
--- a/src/main/java/com/lahirucw/emp/config/SecurityConfig.java
+++ b/src/main/java/com/lahirucw/emp/config/SecurityConfig.java
@@ -1,0 +1,30 @@
+package com.lahirucw.emp.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/auth/**").permitAll()
+                .anyRequest().authenticated()
+            );
+
+        return http.build();
+    }
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=emp
 spring.datasource.url=jdbc:postgresql://ep-yellow-morning-a4gks8el-pooler.us-east-1.aws.neon.tech/employeedb?sslmode=require
 spring.datasource.username=employeedb_owner
-spring.datasource.password=password_goes_here
+spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=update

--- a/src/test/java/com/lahirucw/emp/controller/EmployeeControllerTest.java
+++ b/src/test/java/com/lahirucw/emp/controller/EmployeeControllerTest.java
@@ -94,7 +94,7 @@ public class EmployeeControllerTest {
     }
 
     @Test
-    @WithMockUser(username = "ADMIN", roles = {"USER", "ADMIN"}) 
+    @WithMockUser(roles = {"USER"})
     void testGetAllEmployees() throws Exception {
         List<Employee> employees = Arrays.asList(employee1, employee2);
         when(employeeService.getAllEmployees()).thenReturn(employees);
@@ -112,7 +112,7 @@ public class EmployeeControllerTest {
     }
 
     @Test
-    @WithMockUser(username = "ADMIN", roles = {"USER", "ADMIN"}) 
+    @WithMockUser(roles = {"USER"})
     void testGetEmployeeById_Found() throws Exception {
         when(employeeService.getEmployeeById(1L)).thenReturn(Optional.of(employee1));
         mockMvc.perform(get("/api/employees/{id}", 1L))
@@ -125,7 +125,7 @@ public class EmployeeControllerTest {
     }
 
     @Test
-    @WithMockUser(username = "ADMIN", roles = {"USER", "ADMIN"}) 
+    @WithMockUser(roles = {"USER"})
     void testGetEmployeeById_NotFound() throws Exception {
 
         when(employeeService.getEmployeeById(3L)).thenReturn(Optional.empty());
@@ -152,8 +152,8 @@ public class EmployeeControllerTest {
         when(employeeService.createEmployee(any(Employee.class))).thenReturn(savedEmployee);
 
         mockMvc.perform(post("/api/employees")
-                       .contentType(MediaType.APPLICATION_JSON)
-                       .content(objectMapper.writeValueAsString(createEmployeeDTO)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createEmployeeDTO)))
                .andExpect(status().isCreated())
                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                .andExpect(jsonPath("$.id").value(3L))
@@ -184,8 +184,8 @@ public class EmployeeControllerTest {
         when(employeeService.updateEmployee(eq(employeeId), any(Employee.class))).thenReturn(updatedEmployeeEntity);
 
         mockMvc.perform(put("/api/employees/{id}", employeeId)
-                       .contentType(MediaType.APPLICATION_JSON)
-                       .content(objectMapper.writeValueAsString(updateEmployeeDTO)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateEmployeeDTO)))
                .andExpect(status().isOk()) // Expect HTTP 200 OK
                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                .andExpect(jsonPath("$.id").value(employeeId))
@@ -202,8 +202,8 @@ public class EmployeeControllerTest {
         when(employeeService.getEmployeeById(employeeId)).thenReturn(Optional.empty());
 
         mockMvc.perform(put("/api/employees/{id}", employeeId)
-                       .contentType(MediaType.APPLICATION_JSON)
-                       .content(objectMapper.writeValueAsString(updateEmployeeDTO)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateEmployeeDTO)))
                .andExpect(status().isNotFound());
 
         verify(employeeService, times(1)).getEmployeeById(employeeId);

--- a/target/classes/application.properties
+++ b/target/classes/application.properties
@@ -1,6 +1,5 @@
 spring.application.name=emp
-spring.datasource.url= [url goes here]
-spring.datasource.username= [user name goes here]
-spring.datasource.password= [password goes here]
-spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.url=jdbc:postgresql://ep-yellow-morning-a4gks8el-pooler.us-east-1.aws.neon.tech/employeedb?sslmode=require
+spring.datasource.username=employeedb_owner
+spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
This pull request introduces a new security configuration for the application, updates database credentials in configuration files, and modifies test annotations to simplify user roles. Below is a summary of the most important changes grouped by theme:

### Security Configuration
* Added a new `SecurityConfig` class to configure Spring Security. It enables method-level security, disables CSRF, sets session management to stateless, and permits unauthenticated access to `/api/auth/**` while requiring authentication for all other endpoints. (`src/main/java/com/lahirucw/emp/config/SecurityConfig.java`)

### Configuration Updates
* Updated `application.properties` to include the database URL, username, and an empty password field, replacing placeholder values. (`src/main/resources/application.properties`)
* Updated the compiled `target/classes/application.properties` file with the same database configuration changes. (`target/classes/application.properties`)

### Test Simplifications
* Modified `@WithMockUser` annotations in `EmployeeControllerTest` to remove the explicit `username` field and simplify roles to just `{"USER"}` for the following test methods:
  - `testGetAllEmployees`
  - `testGetEmployeeById_Found`
  - `testGetEmployeeById_NotFound`